### PR TITLE
Simplify conditional removing 'else' statement

### DIFF
--- a/prometheus_to_cloudwatch.go
+++ b/prometheus_to_cloudwatch.go
@@ -173,9 +173,9 @@ func (b *Bridge) Run(ctx context.Context) {
 			count, err := b.publishMetricsToCloudWatch(metricFamilies)
 			if err != nil {
 				log.Println("prometheus-to-cloudwatch: error publishing to CloudWatch:", err)
-			} else {
-				log.Println(fmt.Sprintf("prometheus-to-cloudwatch: published %d metrics to CloudWatch", count))
 			}
+
+			log.Println(fmt.Sprintf("prometheus-to-cloudwatch: published %d metrics to CloudWatch", count))
 
 		case <-ctx.Done():
 			log.Println("prometheus-to-cloudwatch: stopping")


### PR DESCRIPTION
This Pull Request has a very small and simple change. It simplifies a `if` statement
by removing the `else` block once it has no logical effect on how code will execute.

It is a very small contribution. Thank you for this helpful project.