### PR TITLE
Added optional metric filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 ## Usage
 
 
+
+
 __NOTE__: The module accepts parameters as command-line arguments or as ENV variables (or any combination of command-line arguments and ENV vars).
 Command-line arguments take precedence over ENV vars
 
@@ -64,6 +66,8 @@ Command-line arguments take precedence over ENV vars
 | accept_invalid_cert          | ACCEPT_INVALID_CERT          | Accept any certificate during TLS handshake. Insecure, use only for testing   |
 | additional_dimension         | ADDITIONAL_DIMENSION         | Additional dimension specified by NAME=VALUE                                  |
 | replace_dimensions           | REPLACE_DIMENSIONS           | Replace dimensions specified by NAME=VALUE,...                                |
+| include_metrics              | INCLUDE_METRICS              | Only publish the specified metrics (comma-separated list of glob patterns)    |
+| exclude_metrics              | EXCLUDE_METRICS              | Never publish the specified metrics (comma-separated list of glob patterns)   |
 
 
 __NOTE__: If AWS credentials are not provided in the command-line arguments (`aws_access_key_id` and `aws_secret_access_key`)
@@ -99,6 +103,9 @@ export PROMETHEUS_SCRAPE_URL=http://xxxxxxxxxxxx:8080/metrics
 export CERT_PATH=""
 export KEY_PATH=""
 export ACCEPT_INVALID_CERT=true
+# Optionally, restrict the subset of metrics to be exported to CloudWatch
+# export INCLUDE_METRICS='jvm_*'
+# export EXCLUDE_METRICS='jvm_memory_*,jvm_buffer_*'
 
 ./dist/bin/prometheus-to-cloudwatch
 ```
@@ -127,6 +134,8 @@ docker run -i --rm \
         -e CERT_PATH="" \
         -e KEY_PATH="" \
         -e ACCEPT_INVALID_CERT=true \
+        -e INCLUDE_METRICS='' \
+        -e EXCLUDE_METRICS='' \
         prometheus-to-cloudwatch
 ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -60,6 +60,8 @@ usage: |-
   | accept_invalid_cert          | ACCEPT_INVALID_CERT          | Accept any certificate during TLS handshake. Insecure, use only for testing   |
   | additional_dimension         | ADDITIONAL_DIMENSION         | Additional dimension specified by NAME=VALUE                                  |
   | replace_dimensions           | REPLACE_DIMENSIONS           | Replace dimensions specified by NAME=VALUE,...                                |
+  | include_metrics              | INCLUDE_METRICS              | Only publish the specified metrics (comma-separated list of glob patterns)    |
+  | exclude_metrics              | EXCLUDE_METRICS              | Never publish the specified metrics (comma-separated list of glob patterns)   |
 
 
   __NOTE__: If AWS credentials are not provided in the command-line arguments (`aws_access_key_id` and `aws_secret_access_key`)
@@ -91,6 +93,9 @@ examples: |-
   export CERT_PATH=""
   export KEY_PATH=""
   export ACCEPT_INVALID_CERT=true
+  # Optionally, restrict the subset of metrics to be exported to CloudWatch
+  # export INCLUDE_METRICS='jvm_*'
+  # export EXCLUDE_METRICS='jvm_memory_*,jvm_buffer_*'
 
   ./dist/bin/prometheus-to-cloudwatch
   ```
@@ -119,6 +124,8 @@ examples: |-
           -e CERT_PATH="" \
           -e KEY_PATH="" \
           -e ACCEPT_INVALID_CERT=true \
+          -e INCLUDE_METRICS='' \
+          -e EXCLUDE_METRICS='' \
           prometheus-to-cloudwatch
   ```
 

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -9,6 +9,9 @@ env:
   - CERT_PATH
   - KEY_PATH
   - ACCEPT_INVALID_CERT
+  # Optionally:
+  - INCLUDE_METRICS
+  - EXCLUDE_METRICS
 
 secrets:
   - AWS_ACCESS_KEY_ID

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,6 +12,8 @@ env:
   KEY_PATH: ""
   ACCEPT_INVALID_CERT: "true"
   REPLACE_DIMENSIONS: "xxx=yyy,aaa=bbb"
+  INCLUDE_METRICS: ''
+  EXCLUDE_METRICS: ''
 
 secrets:
   AWS_ACCESS_KEY_ID:
@@ -19,7 +21,7 @@ secrets:
 
 image:
   repository: "cloudposse/prometheus-to-cloudwatch"
-  tag: "0.1.2"
+  tag: "0.2.0"
   pullPolicy: "Always"
 
 annotations: {}


### PR DESCRIPTION
Configuration options to provide whitelist and blacklist
patterns for metrics, so that only a subset of available metrics
is exported from Prometheus to CloudWatch