### PR TITLE
Sanitise values before sending to CloudWatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ docker run -i --rm \
         -e CERT_PATH="" \
         -e KEY_PATH="" \
         -e ACCEPT_INVALID_CERT=true \
-        -e INCLUDE_METRICS='' \
-        -e EXCLUDE_METRICS='' \
+        -e INCLUDE_METRICS="" \
+        -e EXCLUDE_METRICS="" \
         prometheus-to-cloudwatch
 ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -124,8 +124,8 @@ examples: |-
           -e CERT_PATH="" \
           -e KEY_PATH="" \
           -e ACCEPT_INVALID_CERT=true \
-          -e INCLUDE_METRICS='' \
-          -e EXCLUDE_METRICS='' \
+          -e INCLUDE_METRICS="" \
+          -e EXCLUDE_METRICS="" \
           prometheus-to-cloudwatch
   ```
 


### PR DESCRIPTION
Throw away data points with known invalid values to avoid the whole batch being rejected by CloudWatch API.