### PR TITLE
Bug fix for helm template

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
                   key: {{ $name | quote }}
 {{- end }}
 {{- end }}
-      resources:
+          resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
When using helm, I got:

`error validating data: ValidationError(Deployment.spec.template.spec): unknown field "resources" in io.k8s.api.core.v1.PodSpec;` 

This is because helm template Deployment has `resources` placed at `Deployment.spec.template.spec.resources` where if should be at `Deployment.spec.template.spec.containers[0].resources` instead.