### PR TITLE
allow to remove dimensions

### DIFF
--- a/prometheus_to_cloudwatch.go
+++ b/prometheus_to_cloudwatch.go
@@ -355,10 +355,10 @@ func getDimensions(m model.Metric, num int, b *Bridge) ([]*cloudwatch.Dimension,
 	}
 
 	names := make([]string, 0, len(m))
-	for k := range m {
-		if !(k == model.MetricNameLabel || k == cwHighResLabel || k == cwUnitLabel) {
-			names = append(names, string(k))
-		}
+	for k, v := range m {
+        	if len(v) > 0 && !(k == model.MetricNameLabel || k == cwHighResLabel || k == cwUnitLabel) {
+	            names = append(names, string(k))
+        	}
 	}
 
 	sort.Strings(names)

--- a/prometheus_to_cloudwatch.go
+++ b/prometheus_to_cloudwatch.go
@@ -373,7 +373,9 @@ func getDimensions(m model.Metric, num int, b *Bridge) ([]*cloudwatch.Dimension,
 				// Don't add replacement if not configured
 				if b.replaceDimensions != nil && len(b.replaceDimensions) > 0 {
 					if replacement, ok := b.replaceDimensions[name]; ok {
-						replacedDims = append(replacedDims, new(cloudwatch.Dimension).SetName(name).SetValue(replacement))
+						if len(replacement) > 0 {
+							replacedDims = append(replacedDims, new(cloudwatch.Dimension).SetName(name).SetValue(replacement))
+						}
 					} else {
 						replacedDims = append(replacedDims, new(cloudwatch.Dimension).SetName(name).SetValue(val))
 					}


### PR DESCRIPTION
allow to remove dimensions using empty values on the "replace_dimensions" parameters.

Example usage: 

parameter: `replace_dimensions`
value: `DIM1=,DIM2=newValue`