### PR TITLE
Expose prometheus metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,6 @@ func keyValMustParse(str, message string) (string, string) {
 	return kv[0], kv[1]
 }
 
-
 // dimensionMatcherListMustParse takes a string and a flag name and exists with a message
 // if it cannot parse as GLOB=dim1,dim2;GLOB2=dim3
 func dimensionMatcherListMustParse(str, flag string) []MatcherWithStringSet {

--- a/main.go
+++ b/main.go
@@ -126,10 +126,10 @@ func startHttpServer(ctx context.Context) {
 
 	<-ctx.Done()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	if err := server.Shutdown(ctx); err != nil {
+	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Fatalln("prometheus-to-cloudwatch: Failed to gracefully stop Http server", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -18,6 +18,11 @@ import (
 	"github.com/gobwas/glob"
 )
 
+const (
+	DEFAULT_LISTEN_ADDRESS = ":9698"
+	DEFAULT_METRICS_PATH = "/metrics"
+)
+
 var defaultForceHighRes, _ = strconv.ParseBool(os.Getenv("FORCE_HIGH_RES"))
 
 var (
@@ -39,8 +44,8 @@ var (
 	includeDimensionsForMetrics = flag.String("include_dimensions_for_metrics", os.Getenv("INCLUDE_DIMENSIONS_FOR_METRICS"), "Only publish the specified dimensions for metrics (semi-colon-separated key values of comma-separated dimensions of METRIC=dim1,dim2;, e.g. 'flink_jobmanager=job_id')")
 	excludeDimensionsForMetrics = flag.String("exclude_dimensions_for_metrics", os.Getenv("EXCLUDE_DIMENSIONS_FOR_METRICS"), "Never publish the specified dimensions for metrics (semi-colon-separated key values of comma-separated dimensions of METRIC=dim1,dim2;, e.g. 'flink_jobmanager=job,host;zk_up=host,pod;')")
 	forceHighRes                = flag.Bool("force_high_res", defaultForceHighRes, "Publish all metrics with high resolution, even when original metrics don't have the label "+cwHighResLabel)
-	listenAddress               = flag.String("listen_address", os.Getenv("LISTEN_ADDRESS"), "Address to expose metrics")
-	metricsPath                 = flag.String("metrics_path", os.Getenv("METRICS_PATH"), "Path under which to expose metrics")
+	listenAddress               = flag.String("listen_address", os.Getenv("LISTEN_ADDRESS"), fmt.Sprintf("Address to expose metrics (default: %s)", DEFAULT_LISTEN_ADDRESS))
+	metricsPath                 = flag.String("metrics_path", os.Getenv("METRICS_PATH"), fmt.Sprintf("Path under which to expose metrics (default: %s)", DEFAULT_METRICS_PATH))
 )
 
 // kevValMustParse takes a string and exits with a message if it cannot parse as KEY=VALUE
@@ -97,12 +102,12 @@ func stringSliceToSet(slice []string) StringSet {
 func startHttpServer(ctx context.Context) {
 	var metricsListenAddress = *listenAddress
 	if metricsListenAddress == "" {
-		metricsListenAddress = ":9698"
+		metricsListenAddress = DEFAULT_LISTEN_ADDRESS
 	}
 
 	var metricsListenPath = *metricsPath
 	if metricsListenPath == "" {
-		metricsListenPath = "/metrics"
+		metricsListenPath = DEFAULT_METRICS_PATH
 	}
 
 	httpServerExitDone := &sync.WaitGroup{}

--- a/prometheus_to_cloudwatch.go
+++ b/prometheus_to_cloudwatch.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"mime"
 	"net/http"
+	"net/url"
 	"sort"
 	"time"
 
@@ -242,38 +243,35 @@ func (b *Bridge) Run(ctx context.Context) {
 func newMetrics(c *Config, r prometheus.Registerer) *metrics {
 	m := &metrics{}
 
+	prometheusScrapeUrl := c.PrometheusScrapeUrl
+	if unescape, err := url.QueryUnescape(c.PrometheusScrapeUrl); err == nil {
+		prometheusScrapeUrl = unescape
+	}
+	labels := map[string]string{
+		"cloudwatchRegion":  c.CloudWatchRegion,
+		"prometheusScrapeUrl": prometheusScrapeUrl,
+	}
+
 	m.publishesTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "cloudwatch_bridge_publishes_total",
 		Help: "Number of publishes to cloudwatch.",
-		ConstLabels: map[string]string{
-			"cloudwatchRegion":  c.CloudWatchRegion,
-			"prometheusScrapeUrl": c.PrometheusScrapeUrl,
-		},
+		ConstLabels: labels,
 	})
 	m.publishErrorsTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "cloudwatch_bridge_publish_errors_total",
 		Help: "Number of cloudwatch publish errors.",
-		ConstLabels: map[string]string{
-			"cloudwatchRegion":  c.CloudWatchRegion,
-			"prometheusScrapeUrl": c.PrometheusScrapeUrl,
-		},
+		ConstLabels: labels,
 	})
 	m.publishDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "cloudwatch_bridge_publish_duration_seconds",
 		Help: "Duration of cloudwatch publishes",
-		ConstLabels: map[string]string{
-			"cloudwatchRegion":  c.CloudWatchRegion,
-			"prometheusScrapeUrl": c.PrometheusScrapeUrl,
-		},
+		ConstLabels: labels,
 	})
 
 	m.metricsTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "cloudwatch_bridge_metrics_total",
 		Help: "Number of mmetrics published to cloudwatch.",
-		ConstLabels: map[string]string{
-			"cloudwatchRegion":  c.CloudWatchRegion,
-			"prometheusScrapeUrl": c.PrometheusScrapeUrl,
-		},
+		ConstLabels: labels,
 	})
 
 	if r != nil {

--- a/prometheus_to_cloudwatch.go
+++ b/prometheus_to_cloudwatch.go
@@ -130,8 +130,6 @@ type Bridge struct {
 	includeDimensionsForMetrics   []MatcherWithStringSet
 	excludeDimensionsForMetrics   []MatcherWithStringSet
 	forceHighRes                  bool
-	listenAddress                 string
-	metricsPath                   string
 	metrics                       *metrics
 }
 

--- a/prometheus_to_cloudwatch.go
+++ b/prometheus_to_cloudwatch.go
@@ -112,12 +112,6 @@ type Config struct {
 
 	// ForceHighRes forces all exported metrics to be sent as custom high-resolution metrics.
 	ForceHighRes bool
-
-	// ListenAddress is the address to expose metrics.
-	ListenAddress string
-
-	// MetricsPath is the path under which to expose metrics.
-	MetricsPath string
 }
 
 // Bridge pushes metrics to AWS CloudWatch
@@ -174,8 +168,6 @@ func NewBridge(c *Config) (*Bridge, error) {
 	b.includeDimensionsForMetrics = c.IncludeDimensionsForMetrics
 	b.excludeDimensionsForMetrics = c.ExcludeDimensionsForMetrics
 	b.forceHighRes = c.ForceHighRes
-	b.listenAddress = c.ListenAddress
-	b.metricsPath = c.MetricsPath
 
 	if c.CloudWatchPublishInterval > 0 {
 		b.cloudWatchPublishInterval = c.CloudWatchPublishInterval


### PR DESCRIPTION
## what
* Exposes metrics from the prometheus-to-cloudwatch service via the standard prometheus scrape endpoint.
* Creates the following metrics:
    * Total Publishes
    * Total Publish Errors
    * Publish Duration
    * Total Metrics
* New port chosen that doesn't collide with existing prometheus exporters.

![image](https://user-images.githubusercontent.com/1904898/80033682-fef08c80-84a1-11ea-98d5-09a1b99ebaae.png)

## why
* There is no current ability to monitor the prometheus-to-cloudwatch service
* This exposes total and error metrics that can allow prometheus alerts to be created that will notify based on failure rate or hung process.
* Monitoring is needed to be able to rely on this service in production environments

## references
* Verify port choice on https://github.com/prometheus/prometheus/wiki/Default-port-allocations and update this with port when merged.