### PR TITLE
Support apps/v1 api version

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.1.2
 description: A Helm chart for prometheus-to-cloudwatch
 name: prometheus-to-cloudwatch
-version: 0.1.2
+version: 0.1.3

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,4 +1,8 @@
+{{- if .Capabilities.APIVersions.Has "apps/v1" }}
+apiVersion: apps/v1
+{{- else }}
 apiVersion: apps/v1beta2
+{{- end }}
 kind: Deployment
 metadata:
   name: {{ include "common.fullname" . }}


### PR DESCRIPTION
Addresses #42 so that the chart can be utilized in newer clusters and not break on helm update (due to invalid api version).